### PR TITLE
fix: type error and remove webContents.destroy before reload

### DIFF
--- a/lib/electron-windows.js
+++ b/lib/electron-windows.js
@@ -52,11 +52,16 @@ class WindowsManager {
       _loadingView.webContents.loadURL(loadingViewOptions.url);
     };
 
+    const onReload = () => {
+      window.removeBrowserView(_loadingView);
+    };
+
     const onFailure = () => {
       if (_loadingView.webContents && !_loadingView.webContents.isDestroyed()) {
-        window.removeBrowserView(_loadingView);
-        // https://github.com/electron/electron/issues/10096
         _loadingView.webContents.destroy();
+      }
+      if (window) {
+        window.removeBrowserView(_loadingView);
       }
     };
 
@@ -81,7 +86,7 @@ class WindowsManager {
         loadLoadingView();
       }
     });
-    window.webContents.on('dom-ready', onFailure);
+    window.webContents.on('dom-ready', onReload);
     window.webContents.on('crashed', onFailure);
     window.webContents.on('unresponsive', onFailure);
     window.webContents.on('did-fail-load', onFailure);


### PR DESCRIPTION
- Fix a type error 'removeBrowserView of undefined' happened when BrowserWindow was destroyed while BrowserView was still alive. 
- Separate the handlers of event 'dom-ready' and other error event.  The `onReload` handles event 'dom-ready' without destroying webContents since the crash bug has been fixed in https://github.com/electron/electron/pull/31796