### PR TITLE
fix: destroy loadingView after dom ready

### DIFF
--- a/lib/electron-windows.js
+++ b/lib/electron-windows.js
@@ -52,10 +52,6 @@ class WindowsManager {
       _loadingView.webContents.loadURL(loadingViewOptions.url);
     };
 
-    const onDomReady = () => {
-      window.removeBrowserView(_loadingView);
-    };
-
     const onFailure = () => {
       if (_loadingView.webContents && !_loadingView.webContents.isDestroyed()) {
         _loadingView.webContents.destroy();
@@ -86,7 +82,7 @@ class WindowsManager {
         loadLoadingView();
       }
     });
-    window.webContents.on('dom-ready', onDomReady);
+    window.webContents.on('dom-ready', onFailure);
     window.webContents.on('crashed', onFailure);
     window.webContents.on('unresponsive', onFailure);
     window.webContents.on('did-fail-load', onFailure);


### PR DESCRIPTION
修复 dom-ready 后未销毁 BrowserView 问题。