### PR TITLE
chore: optimize the robustness of e2e tests

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,7 +7,7 @@ module.exports = defineConfig({
   testDir: './test/e2e',
   fullyParallel: false,
   forbidOnly: isCI,
-  retries: 0,
+  retries: isCI ? 1 : 0,
   workers: 1,
   reporter: 'null',
   use: {

--- a/test/e2e/electron-windows.e2e.test.js
+++ b/test/e2e/electron-windows.e2e.test.js
@@ -28,7 +28,7 @@ test.describe('test/e2e/electron-windows.e2e.test.js', () => {
 
   test('loadingView option is working', async () => {
     const window = await electronApp.firstWindow();
-
+    await window.waitForLoadState('domcontentloaded');
     expect(await window.title()).toBe('Loading');
     expect(window.url()).toMatch(/renderer\/loading\.html$/);
   });
@@ -48,7 +48,7 @@ test.describe('test/e2e/electron-windows.e2e.test.js', () => {
     await wait();
     const window = await electronApp.firstWindow();
     await window.click('button#new-online');
-    await wait();
+    await wait(10000);
     const windows = electronApp.windows();
 
     expect(windows.length).toBeGreaterThan(1);


### PR DESCRIPTION
Fix the issue that the window webcontent might not be ready when trying to access its title.