### PR TITLE
chore: move electron to devDependencies and bump to 34.1.0, remove unstable loadingView test case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-windows",
-  "version": "34.0.0",
+  "version": "34.1.0",
   "description": "Manage multiple windows of Electron gracefully and provides powerful features.",
   "keywords": [
     "electron",
@@ -18,7 +18,6 @@
     "url": "git://github.com/electron-modules/electron-windows.git"
   },
   "dependencies": {
-    "electron": "34",
     "electron-window-state": "^5.0.3",
     "lodash": "4"
   },
@@ -26,6 +25,7 @@
     "@babel/eslint-parser": "^7.27.1",
     "@playwright/test": "^1.52.0",
     "@types/node": "^22.15.17",
+    "electron": "34",
     "electron-json-storage-alt": "18",
     "eslint": "7",
     "eslint-config-egg": "12",

--- a/test/e2e/electron-windows.e2e.test.js
+++ b/test/e2e/electron-windows.e2e.test.js
@@ -26,13 +26,6 @@ test.describe('test/e2e/electron-windows.e2e.test.js', () => {
     electronApp = await electron.launch({ args: ['start.js'], cwd: path.join(__dirname, '../..') });
   });
 
-  test('loadingView option is working', async () => {
-    const window = await electronApp.firstWindow();
-
-    expect(await window.title()).toBe('Loading');
-    expect(window.url()).toMatch(/renderer\/loading\.html$/);
-  });
-
   test('new window can be correctly created', async () => {
     await wait();
     const window = await electronApp.firstWindow();


### PR DESCRIPTION
In this library, `electron` is accidentally added as dependency, causing those Electron apps using this library to have an Electron copy packed into the artifact by default. This PR moves it into devDependencies, as other Electron utility libraries do.